### PR TITLE
Handle Android RN 0.47 breaking change

### DIFF
--- a/android/src/main/java/com/rctunderdark/NetworkManagerPackage.java
+++ b/android/src/main/java/com/rctunderdark/NetworkManagerPackage.java
@@ -22,7 +22,7 @@ public class NetworkManagerPackage implements ReactPackage {
         );
     }
 
-    @Override
+   // @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
This makes the library work in react-native 0.47.
see this same change made in other libraries:

https://github.com/jsierles/react-native-audio/pull/206
https://github.com/MacKentoch/react-native-beacons-manager/pull/36

It's backwards compatible so no need to worry