### PR TITLE
Prevent returning after a single loop before new user can be appended…

### DIFF
--- a/ios/react-native-bluetooth-cross-platform/NetworkCommunicator.swift
+++ b/ios/react-native-bluetooth-cross-platform/NetworkCommunicator.swift
@@ -176,8 +176,9 @@ public class NetworkCommunicator: TransportHandler, MessageEncoder, MessageDecod
       if nearbyUsers[i].deviceId == user.deviceId && nearbyUsers[i].mode != user.mode {
         nearbyUsers[i].mode = user.mode;
         return;
+      } else if nearbyUsers[i].deviceId == user.deviceId {
+        return;
       }
-      return;
     }
     nearbyUsers.append(user)
     self.sendEvent(withName: "detectedUser", body: user.getJSUser("new user"))


### PR DESCRIPTION
… to nearbyUsers and emit "detectedUser"

Fixes issue #32

The `for` loop was returning after the first loop regardless of whether the user was already detected or not. This change will make it return only if the user actually exists, otherwise it will append the user to `nearbyUsers` and emit "detectedUser".