### PR TITLE
Initialize broadcastTimer to null and check if timer is null before…

### DIFF
--- a/android/src/main/java/com/rctunderdark/NetworkCommunicator.java
+++ b/android/src/main/java/com/rctunderdark/NetworkCommunicator.java
@@ -23,7 +23,7 @@ public class NetworkCommunicator extends TransportHandler implements MessageDeco
     private String deviceDelimeter = "$#%";
     private String deviceID = Settings.Secure.getString(context.getContentResolver(), Secure.ANDROID_ID);
     private String displayName = BluetoothAdapter.getDefaultAdapter().getName();
-    private Timer broadcastTimer;
+    private Timer broadcastTimer = null;
     private Boolean isRunning = false;
     private User.PeerType type = User.PeerType.OFFLINE;
 
@@ -106,7 +106,9 @@ public class NetworkCommunicator extends TransportHandler implements MessageDeco
 
     @Override
     public void stopTransport() {
-        broadcastTimer.cancel();
+        if (broadcastTimer != null) {
+            broadcastTimer.cancel();
+        }
         broadcastTimer = null;
         isRunning = false;
     }


### PR DESCRIPTION
…attempting to invoke cancel()

Patch in reference to #36 

The only difference is that `broadcastTimer` is initialized to `null` value since that is what it becomes after `broadcastTimer.cancel()`, so that it can be checked against that value, i.e. `broadcastTimer != null` before invoking `broadcastTimer.cancel()`.
`