### PR TITLE
fix for NSInternalInconsistencyException - caused by nil bridge in TransportHandler

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,16 @@
 import {
   NativeModules,
   NativeEventEmitter,
+  Platform,
 } from 'react-native'
 import React from 'react'
 
 var NativeManager = NativeModules.NetworkManager
-var NativeEmitter =  new NativeEventEmitter(NativeModules.NetworkManagerEventEmitter)
+
+var NativeEmitter = new NativeEventEmitter(Platform.select({
+  ios: NativeModules.NetworkManagerEventEmitter,
+  android: NativeModules.NetworkManager,
+}))
 
 class NetworkManager {
   // kind can be one of "WIFI", "BT", and "WIFI-BT"

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import {
 import React from 'react'
 
 var NativeManager = NativeModules.NetworkManager
-var NativeEmitter =  new NativeEventEmitter(NativeModules.NetworkManager)
+var NativeEmitter =  new NativeEventEmitter(NativeModules.NetworkManagerEventEmitter)
 
 class NetworkManager {
   // kind can be one of "WIFI", "BT", and "WIFI-BT"

--- a/ios/react-native-bluetooth-cross-platform/EventEmitter.swift
+++ b/ios/react-native-bluetooth-cross-platform/EventEmitter.swift
@@ -1,0 +1,29 @@
+class EventEmitter {
+
+  /// Shared Instance.
+  public static var sharedInstance = EventEmitter()
+
+  // ReactNativeEventEmitter is instantiated by React Native with the bridge.
+  private static var eventEmitter: NetworkManagerEventEmitter!
+
+  private init() {}
+
+  // When React Native instantiates the emitter it is registered here.
+  func registerEventEmitter(eventEmitter: NetworkManagerEventEmitter) {
+    EventEmitter.eventEmitter = eventEmitter
+  }
+
+  func dispatch(name: String, body: Any?) {
+    EventEmitter.eventEmitter.sendEvent(withName: name, body: body)
+  }
+
+  /// All Events which must be support by React Native.
+  lazy var allEvents: [String] = {
+    var allEventNames: [String] = ["lostUser","detectedUser", "messageReceived", "connectedToUser", "receivedInvitation"]
+    
+    // Append all events here
+    
+    return allEventNames
+  }()
+
+}

--- a/ios/react-native-bluetooth-cross-platform/EventEmitter.swift
+++ b/ios/react-native-bluetooth-cross-platform/EventEmitter.swift
@@ -3,7 +3,6 @@ class EventEmitter {
   /// Shared Instance.
   public static var sharedInstance = EventEmitter()
 
-  // ReactNativeEventEmitter is instantiated by React Native with the bridge.
   private static var eventEmitter: NetworkManagerEventEmitter!
 
   private init() {}
@@ -20,8 +19,6 @@ class EventEmitter {
   /// All Events which must be support by React Native.
   lazy var allEvents: [String] = {
     var allEventNames: [String] = ["lostUser","detectedUser", "messageReceived", "connectedToUser", "receivedInvitation"]
-    
-    // Append all events here
     
     return allEventNames
   }()

--- a/ios/react-native-bluetooth-cross-platform/NetworkCommunicator.swift
+++ b/ios/react-native-bluetooth-cross-platform/NetworkCommunicator.swift
@@ -181,10 +181,8 @@ public class NetworkCommunicator: TransportHandler, MessageEncoder, MessageDecod
       }
     }
     nearbyUsers.append(user)
-    self.sendEvent(withName: "detectedUser", body: user.getJSUser("new user"))
-  }
-  
-  override open func supportedEvents() -> [String]! {
-    return ["lostUser","detectedUser", "messageReceived", "connectedToUser", "receivedInvitation"]
+    if (self.advertiseTimer != nil) {
+      self.sendEvent(withName: "detectedUser", body: user.getJSUser("new user"))
+    }
   }
 }

--- a/ios/react-native-bluetooth-cross-platform/NetworkManager.swift
+++ b/ios/react-native-bluetooth-cross-platform/NetworkManager.swift
@@ -86,8 +86,5 @@ public class NetworkManager: NetworkCommunicator, ReactNearby {
   @objc public  func sendMessage(_ message: String, userId:String) {
     self.sendMessage(message: message, userId: userId)
   }
-  
-  override public func supportedEvents() -> [String]! {
-    return ["lostUser","detectedUser", "messageReceived", "connectedToUser", "receivedInvitation"]
-  }
+
 }

--- a/ios/react-native-bluetooth-cross-platform/NetworkManagerEventEmitter.m
+++ b/ios/react-native-bluetooth-cross-platform/NetworkManagerEventEmitter.m
@@ -1,0 +1,13 @@
+//
+// See: http://facebook.github.io/react-native/releases/0.43/docs/native-modules-ios.html#exporting-swift
+//
+
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+@interface RCT_EXTERN_MODULE(NetworkManagerEventEmitter, RCTEventEmitter)
+
+RCT_EXTERN_METHOD(supportedEvents)
+
+@end

--- a/ios/react-native-bluetooth-cross-platform/NetworkManagerEventEmitter.swift
+++ b/ios/react-native-bluetooth-cross-platform/NetworkManagerEventEmitter.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+@objc(NetworkManagerEventEmitter)
+open class NetworkManagerEventEmitter: RCTEventEmitter {
+  
+  override init() {
+    super.init()
+    EventEmitter.sharedInstance.registerEventEmitter(eventEmitter: self)
+  }
+  
+  /// Base overide for RCTEventEmitter.
+  ///
+  /// - Returns: all supported events
+  @objc open override func supportedEvents() -> [String] {
+    return EventEmitter.sharedInstance.allEvents
+  }
+  
+}

--- a/ios/react-native-bluetooth-cross-platform/TransportHandler.swift
+++ b/ios/react-native-bluetooth-cross-platform/TransportHandler.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Underdark
 
-open class TransportHandler: RCTEventEmitter, UDTransportDelegate {
+open class TransportHandler: NSObject, UDTransportDelegate {
   
   // delimiterse
   private var type: User.PeerType = User.PeerType.OFFLINE
@@ -75,8 +75,7 @@ open class TransportHandler: RCTEventEmitter, UDTransportDelegate {
     // handle this in network communicatorwith proper encoder and decoder functionality
   }
   
-  override open func supportedEvents() -> [String]! {
-    return ["lostUser","detectedUser", "messageReceived", "connectedToUser", "receivedInvitation"]
+  public func sendEvent(withName: String, body: Any?) {
+    EventEmitter.sharedInstance.dispatch(name: withName, body: body)
   }
-  
 }


### PR DESCRIPTION
Love the lib! Building a multiplayer game and it works well 😃

When using the library I got this error (#30):
```
NSInternalInconsistencyException. This is probably because you've explicitly synthesized the bridge in NetworkManager, even though it's inherited from RCTEventEmitter.
```

To fix this I refactored out the RCTEventEmitter into a separate object which is instantiated on app start, which TransportHandler can then use when it needs.

I followed this guide https://gist.github.com/brennanMKE/1ebba84a0fd7c2e8b481e4f8a5349b99
I'm not a swift programmer by any stretch, so there may be a better way of doing this but this works 😊
