### PR TITLE
fix android simulator crash

### DIFF
--- a/android/src/main/java/com/rctunderdark/NetworkCommunicator.java
+++ b/android/src/main/java/com/rctunderdark/NetworkCommunicator.java
@@ -22,7 +22,7 @@ public class NetworkCommunicator extends TransportHandler implements MessageDeco
     private String typeDelimeter = "%$#";
     private String deviceDelimeter = "$#%";
     private String deviceID = Settings.Secure.getString(context.getContentResolver(), Secure.ANDROID_ID);
-    private String displayName = BluetoothAdapter.getDefaultAdapter().getName();
+    private String displayName;
     private Timer broadcastTimer = null;
     private Boolean isRunning = false;
     private User.PeerType type = User.PeerType.OFFLINE;
@@ -30,6 +30,9 @@ public class NetworkCommunicator extends TransportHandler implements MessageDeco
     // INITIALIAZATION
     public NetworkCommunicator(ReactApplicationContext reactContext) {
         super(reactContext);
+        if (BluetoothAdapter.getDefaultAdapter() != null) {
+            displayName = BluetoothAdapter.getDefaultAdapter().getName();
+        }
     }
 
     @Override


### PR DESCRIPTION
`BluetoothAdapter.getDefaultAdapter()` returns null in the android simulator, so calling `BluetoothAdapter.getDefaultAdapter().getName()` throws an exception.

On initialisation this checks whether `BluetoothAdapter.getDefaultAdapter()` isn't null and only then tries to run `getName()`