### PR TITLE
Improving iOS concurrency in eventHandler logic

### DIFF
--- a/ios/react-native-bluetooth-cross-platform/TransportHandler.swift
+++ b/ios/react-native-bluetooth-cross-platform/TransportHandler.swift
@@ -11,6 +11,10 @@ open class TransportHandler: RCTEventEmitter, UDTransportDelegate {
   private var nodeId: Int64 = 0
   internal var links = [UDLink]()
   internal var nearbyUsers = [User]()
+
+  // ratkinson - setting up a dispatch queue to handle "links" and "nearbyUsers"
+  // logic syncronously in eventHandlers
+  let serialQueue = DispatchQueue(label: "serialQueue")
   
   // MARK: START TRANSPORT
   public func initTransport(_ kind: String, inType: User.PeerType) {
@@ -42,6 +46,7 @@ open class TransportHandler: RCTEventEmitter, UDTransportDelegate {
     }
     transport?.start()
   }
+
   // MARK: stop transport
   open func stopTransport() {
     transport?.stop()
@@ -49,28 +54,36 @@ open class TransportHandler: RCTEventEmitter, UDTransportDelegate {
   
   // MARK: TRansport delegate
   public func transport(_ transport: UDTransport, linkConnected link: UDLink) {
-    links.append(link)
+    serialQueue.sync {
+      links.append(link)
+    }
   }
   
   public func transport(_ transport: UDTransport, linkDisconnected link: UDLink) {
-    var i = 0;
-    while i < links.count {
-      if link.nodeId == links[i].nodeId {
-        links.remove(at: i)
-      } else {
-        i += 1
+    serialQueue.sync {
+      let linksCount = links.count
+      var i = (linksCount - 1);
+
+      while i >= 0 {
+        if link.nodeId == links[i].nodeId {
+          links.remove(at: i)
+        }
+        i -= 1
       }
-    }
-    i = 0;
-    while i < nearbyUsers.count {
-      if link.nodeId == nearbyUsers[i].link.nodeId {
-        self.sendEvent(withName: "lostUser", body:  nearbyUsers[i].getJSUser("lost peer"))
-        nearbyUsers.remove(at: i)
-      } else {
-        i += 1
+
+      let nearbyUserCount = nearbyUsers.count
+      i = (nearbyUserCount - 1)
+
+      while i >= 0 {
+        if link.nodeId == nearbyUsers[i].link.nodeId {
+          self.sendEvent(withName: "lostUser", body:  nearbyUsers[i].getJSUser("lost peer"))
+          nearbyUsers.remove(at: i)
+        }
+        i -= 1
       }
     }
   }
+
   public func transport(_ transport: UDTransport, link: UDLink, didReceiveFrame frameData: Data) {
     // handle this in network communicatorwith proper encoder and decoder functionality
   }

--- a/ios/react-native-bluetooth-cross-platform/TransportHandler.swift
+++ b/ios/react-native-bluetooth-cross-platform/TransportHandler.swift
@@ -12,7 +12,7 @@ open class TransportHandler: RCTEventEmitter, UDTransportDelegate {
   internal var links = [UDLink]()
   internal var nearbyUsers = [User]()
 
-  // ratkinson - setting up a dispatch queue to handle "links" and "nearbyUsers"
+  // setting up a dispatch queue to handle "links" and "nearbyUsers"
   // logic syncronously in eventHandlers
   let serialQueue = DispatchQueue(label: "serialQueue")
   


### PR DESCRIPTION
Hello @alexkendall !

I have been using your library for a few months now and it has been awesome! 🎉Has allowed me to build an app that would've been unthinkable otherwise.

Unfortunately, I have noticed that there are some app crashes that appear to stem from the library. I'm not an expert on this source code nor an iOS developer, but after some debugging it appears that there were issues with multiple functions manipulating the `links` and `nearbyUsers` arrays simultaneously.

The errors were as below: 
<img width="958" alt="screen shot 2018-08-31 at 2 30 05 pm" src="https://user-images.githubusercontent.com/13787517/45058114-a61e7700-b065-11e8-9b47-36113f66d1c4.png">

<img width="1025" alt="screen shot 2018-08-31 at 4 13 25 pm" src="https://user-images.githubusercontent.com/13787517/45058127-aa4a9480-b065-11e8-98e6-16221a175eea.png">

These crashes occurred when I had multiple devices connected, and started toggling some of them in and out of airplane mode to simulate disconnection and reconnection.

I fixed the issue used a synchronous dispatch queue and looping backwards instead of forwards to protect the `links` and `nearbyUsers` array indices.

I went ahead and forked the repo to make changes and everything looks good on my end now. I just wanted to propose this code to you in case you feel it is an improvement to the codebase.

Also, if you see anything that I've done that doesn't seem right feel free to let me know. Thanks!
