### PR TITLE
Check if argument `id` is null before searching for whether `nearbyUs…

### DIFF
--- a/android/src/main/java/com/rctunderdark/NetworkCommunicator.java
+++ b/android/src/main/java/com/rctunderdark/NetworkCommunicator.java
@@ -241,6 +241,7 @@ public class NetworkCommunicator extends TransportHandler implements MessageDeco
 
     // UTILITY
     public User findUser(String id) {
+        if (id == null) return null;
         for (int i = 0; i < nearbyUsers.size(); ++i) {
             if (nearbyUsers.elementAt(i).deviceId.contains(id)) {
                 return nearbyUsers.elementAt(i);


### PR DESCRIPTION
…ers` has a `deviceId` that contains `id`. When `(id  == null) return null` because not doing so causes `nearbyUsers.elementAt(i).deviceId.contains(id)` to attempt to invoke `toString()` on `id` when it is null resulting in a crash.

The resulting error message: 

```
2019-04-20 21:26:52.578 10574-10642/? E/AndroidRuntime: FATAL EXCEPTION: mqt_native_modules
    Process: com.app, PID: 10574
    java.lang.NullPointerException: Attempt to invoke interface method 'java.lang.String java.lang.CharSequence.toString()' on a null object reference
        at java.lang.String.contains(String.java:2196)
        at com.rctunderdark.NetworkCommunicator.findUser(NetworkCommunicator.java:245)
        at com.rctunderdark.NetworkCommunicator.sendMessage(NetworkCommunicator.java:235)
        at com.rctunderdark.NetworkManager.sendMessage(NetworkManager.java:29)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
        at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:158)
        at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
        at android.os.Handler.handleCallback(Handler.java:873)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:29)
        at android.os.Looper.loop(Looper.java:193)
        at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:232)
        at java.lang.Thread.run(Thread.java:764)
```
**Steps to reproduce**
This happens when previously connected devices (one being Android, hence the Java fix) disconnect and then without restarting the application, they attempt to reconnect.