### PR TITLE
Emit user redetected upon reconnection

### DIFF
--- a/android/src/main/java/com/rctunderdark/NetworkCommunicator.java
+++ b/android/src/main/java/com/rctunderdark/NetworkCommunicator.java
@@ -250,6 +250,8 @@ public class NetworkCommunicator extends TransportHandler implements MessageDeco
     }
     private void checkForNewUser(User user) {
         if(findUser(user.deviceId) != null) {
+            context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                .emit("redetectedUser", user.getJSUser());
             return;
         }
         nearbyUsers.add(user);

--- a/index.js
+++ b/index.js
@@ -53,6 +53,12 @@ class NetworkManager {
     (peer) =>  callback(peer)
     )
   }
+  addPeerRedetectedListener(callback) {
+    return NativeEmitter.addListener(
+    'redetectedUser',
+    (peer) =>  callback(peer)
+    )
+  }
   addPeerLostListener(callback) {
     return NativeEmitter.addListener(
     'lostUser',

--- a/ios/react-native-bluetooth-cross-platform/NetworkCommunicator.swift
+++ b/ios/react-native-bluetooth-cross-platform/NetworkCommunicator.swift
@@ -189,9 +189,11 @@ public class NetworkCommunicator: TransportHandler, MessageEncoder, MessageDecod
 
       for i in 0..<nearbyUserCount {
         if nearbyUsers[i].deviceId == user.deviceId && nearbyUsers[i].mode != user.mode {
+          self.sendEvent(withName: "redetectedUser", body: user.getJSUser("redetected user"))
           nearbyUsers[i].mode = user.mode;
           return;
         } else if nearbyUsers[i].deviceId == user.deviceId {
+          self.sendEvent(withName: "redetectedUser", body: user.getJSUser("redetected user"))
           return;
         }
       }
@@ -203,6 +205,6 @@ public class NetworkCommunicator: TransportHandler, MessageEncoder, MessageDecod
   }
   
   override open func supportedEvents() -> [String]! {
-    return ["lostUser","detectedUser", "messageReceived", "connectedToUser", "receivedInvitation"]
+    return ["lostUser", "detectedUser", "redetectedUser", "messageReceived", "connectedToUser", "receivedInvitation"]
   }
 }

--- a/ios/react-native-bluetooth-cross-platform/NetworkManager.swift
+++ b/ios/react-native-bluetooth-cross-platform/NetworkManager.swift
@@ -88,6 +88,6 @@ public class NetworkManager: NetworkCommunicator, ReactNearby {
   }
   
   override public func supportedEvents() -> [String]! {
-    return ["lostUser","detectedUser", "messageReceived", "connectedToUser", "receivedInvitation"]
+    return ["lostUser", "detectedUser", "redetectedUser", "messageReceived", "connectedToUser", "receivedInvitation"]
   }
 }

--- a/ios/react-native-bluetooth-cross-platform/TransportHandler.swift
+++ b/ios/react-native-bluetooth-cross-platform/TransportHandler.swift
@@ -89,7 +89,7 @@ open class TransportHandler: RCTEventEmitter, UDTransportDelegate {
   }
   
   override open func supportedEvents() -> [String]! {
-    return ["lostUser","detectedUser", "messageReceived", "connectedToUser", "receivedInvitation"]
+    return ["lostUser", "detectedUser", "redetectedUser", "messageReceived", "connectedToUser", "receivedInvitation"]
   }
   
 }

--- a/sdk.md
+++ b/sdk.md
@@ -28,6 +28,7 @@ There are several listeners that can be added to monitor events concerning peers
 
 ```
 addPeerDetectedListener(callback)
+addPeerRedetectedListener(callback)
 addPeerLostListener(callback)
 addReceivedMessageListener(callback)
 addInviteListener(callback)
@@ -57,9 +58,10 @@ Simply registering a reference to each listener will allow you to keep track of 
 componentDidMount() {
     this.listener1 = addPeerDetectedListener(callback)
     this.listener2 = addPeerLostListener(callback)
-    this.listener3 = addReceivedMessageListener(callback)
-    this.listener4 = addInviteListener(callback)
-    this.listener5 = addConnectedListener(callback)
+    this.listener3 = addPeerRedetectedListener(callback)
+    this.listener4 = addReceivedMessageListener(callback)
+    this.listener5 = addInviteListener(callback)
+    this.listener6 = addConnectedListener(callback)
 }
 
 componentWillUnmount() {
@@ -68,6 +70,7 @@ componentWillUnmount() {
     this.listener3.remove()
     this.listener4.remove()
     this.listener5.remove()
+    this.listener6.remove()
 }
 ```
 


### PR DESCRIPTION
**The problem**
Upon reconnecting to the network, the "userDetected" event does not fire due to returning null in `checkForNewUser(user)`. This is unfortunate because there may be a number of reasons why the user disconnected (switched screens, etc) and may wish to reconnect to nearby users, usually by letting them know they've been "detected" or in this case, "redetected".

**The solution**
Emit a "redetectedUser" event that's similar to "detectedUser" but under the condition that the user already exists in the `nearbyUsers` list.

**The reason**
This helps to bridge a disconnected user back into whatever ongoing processes and can facilitate in syncing whatever state there is back up with the reconnected user.